### PR TITLE
remove un-necessary code

### DIFF
--- a/61232980-htmlwebpackplugin-use-property-chunks-renders-htmlwebpackplugin-files-css-empty/src/index.template
+++ b/61232980-htmlwebpackplugin-use-property-chunks-renders-htmlwebpackplugin-files-css-empty/src/index.template
@@ -7,19 +7,6 @@
 	<% } %>
 	<title>Stack Question</title>
 
-	<!-- CSS Bundles --><% for (var item in htmlWebpackPlugin.files.css) { %>
-	<link href="<%= htmlWebpackPlugin.files.css[item] %>" rel="stylesheet">
-	<% } %>
-	<!-- CSS files Gone -->
-
-	<!-- JavaScript Vendors --><% for (var item in htmlWebpackPlugin.options.chunks ) { %>
-	<script src="<%= htmlWebpackPlugin.options.chunks[item] %>"></script>
-	<% } %>
-	<!-- Hash postfix gone -->
-	<% for (var item in htmlWebpackPlugin.files.js ) { %>
-	<script src="<%= htmlWebpackPlugin.files.js[item] %>"></script>
-	<% } %>
-
 </head>
 
 <body>

--- a/61232980-htmlwebpackplugin-use-property-chunks-renders-htmlwebpackplugin-files-css-empty/webpack.config.js
+++ b/61232980-htmlwebpackplugin-use-property-chunks-renders-htmlwebpackplugin-files-css-empty/webpack.config.js
@@ -63,16 +63,7 @@ module.exports = {
 
 		new HtmlWebpackPlugin({
 			filename: Path.resolve(__dirname, "dist/index.html"),
-
-			chunks: [
-				`jquery.js`,
-				`angular.js`,
-				`app.js`,
-			],
-			chunksSortMode: "manual",
-
 			hash: true,
-			inject: false,
 			template: Path.join(__dirname, "/src/index.template"),
 		})
 	],


### PR DESCRIPTION
Since you are importing jquery & angular in your bundle, there is no need to specify what chunks should be part of the HTML.

Webpack will define the order by the imports order.